### PR TITLE
feat: rebrand app from "Devefinance Store" to "Healthy Spread"

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -89,7 +89,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="http" android:host="devefinance.com"/>
+                <data android:scheme="http" android:host="healthyspread.com"/>
                 <data android:scheme="https"/>
             </intent-filter>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Devefinance Store</string>
+    <string name="app_name">Healthy Spread</string>
 
     <!-- Replace "000000000000" with your Facebook App ID here. -->
     <string name="facebook_app_id"></string>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -552,7 +552,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Devefinance_Store;
+				INFOPLIST_KEY_CFBundleDisplayName = Healthy Spread;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.shopping";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -698,7 +698,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Devefinance_Store;
+				INFOPLIST_KEY_CFBundleDisplayName = Healthy Spread;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.shopping";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -737,7 +737,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Devefinance_Store;
+				INFOPLIST_KEY_CFBundleDisplayName = Healthy Spread;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.shopping";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Devefinance Store</string>
+	<string>Healthy Spread</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -39,7 +39,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>devefinance.com</string>
+			<string>healthyspread.com</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>https</string>
@@ -49,7 +49,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>devefinance.com</string>
+			<string>healthyspread.com</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>http</string>
@@ -67,7 +67,7 @@
 	<key>FacebookClientToken</key>
 	<string></string>
 	<key>FacebookDisplayName</key>
-	<string>Devefinance Store</string>
+	<string>Healthy Spread</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -10,8 +10,8 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>webcredentials:devefinance.com</string>
-		<string>applinks:devefinance.com</string>
+		<string>webcredentials:healthyspread.com</string>
+		<string>applinks:healthyspread.com</string>
 	</array>
 </dict>
 </plist>

--- a/ios/Runner/en.lproj/InfoPlist.strings
+++ b/ios/Runner/en.lproj/InfoPlist.strings
@@ -5,4 +5,4 @@
   Created by M.R.E on 19/02/2025.
   
 */
-"CFBundleDisplayName" = "Devefinance Store";
+"CFBundleDisplayName" = "Healthy Spread";

--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -25,7 +25,7 @@ class AppConfig {
   // static String copyright_text =
   //     "@ Deve Finance " + this_year; //this shows in the splash screen
   static const String app_name_ar = "متجر ديفي";
-  static const String app_name_en = "Devefinance Store";
+  static const String app_name_en = "Healthy Spread";
 
   /// This get the name of the application in deviceLocale
   static String appNameOnDeviceLang =
@@ -62,7 +62,7 @@ class AppConfig {
   static const bool HTTPS =
       true; //if you are using localhost , set this to false
   static const DOMAIN_PATH =
-      "devefinance.com"; //use only domain name without http:// or https://
+      "healthyspread.com"; //use only domain name without http:// or https://
 
   //do not configure these below
   static const String API_ENDPATH = "api/v2";

--- a/lib/dummy_data/messengers.dart
+++ b/lib/dummy_data/messengers.dart
@@ -16,7 +16,7 @@ final List<Messenger> messengerList = [
   Messenger(
     id: "2",
     image: AppImages.loginRegisteration,
-    name: "Devefinance Store",
+    name: "Healthy Spread",
   ),
   Messenger(
     id: "3",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -267,7 +267,7 @@
   "featured_categories_ucf": "Featured Categories",
   "featured_products_ucf": "Featured Products",
   "all_products_ucf": "All Products",
-  "search_in_active_ecommerce_cms": "Search In Devefinance Store...",
+  "search_in_active_ecommerce_cms": "Search In Healthy Spread...",
   "no_carousel_image_found": "No carousel image found",
   "no_category_found": "No category found",
   "categories_ucf": "Categories",

--- a/lib/screens/home/templates/classic.dart
+++ b/lib/screens/home/templates/classic.dart
@@ -111,7 +111,7 @@ class _ClassicScreenState extends State<ClassicScreen>
                             delegate: SliverChildListDelegate([
                               // Padding(
                               //   padding: const EdgeInsets.symmetric(horizontal: 20.0),
-                              //   child: Image.network("https://devefinance.com/public/uploads/all/Ryto4mRZFjxR8INkhLs1DFyX6eoamXKIxXEDFBZM.png"),//TODO:# banner
+                              //   child: Image.network("https://healthyspread.com/public/uploads/all/Ryto4mRZFjxR8INkhLs1DFyX6eoamXKIxXEDFBZM.png"),//TODO:# banner
                               // ),
                               TodaysDealProductsWidget(
                                 homePresenter: homeData,

--- a/lib/screens/home/templates/metro.dart
+++ b/lib/screens/home/templates/metro.dart
@@ -111,7 +111,7 @@ class _MetroScreenState extends State<MetroScreen>
                             delegate: SliverChildListDelegate([
                               // Padding(
                               //   padding: const EdgeInsets.symmetric(horizontal: 20.0),
-                              //   child: Image.network("https://devefinance.com/public/uploads/all/Ryto4mRZFjxR8INkhLs1DFyX6eoamXKIxXEDFBZM.png"),//TODO:# banner
+                              //   child: Image.network("https://healthyspread.com/public/uploads/all/Ryto4mRZFjxR8INkhLs1DFyX6eoamXKIxXEDFBZM.png"),//TODO:# banner
                               // ),
                               TodaysDealProductsWidget(
                                 homePresenter: homeData,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: active_ecommerce_cms_demo_app
-description: This is the flutter mobile application for Devefinance Store
+description: This is the flutter mobile application for Healthy Spread
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.


### PR DESCRIPTION
- Updated AndroidManifest, Info.plist, and Runner.entitlements with new domain: healthyspread.com
- Changed app name in strings.xml, InfoPlist.strings, and project.pbxproj to "Healthy Spread"
- Modified `app_config.dart` constants to reflect new branding (name and domain)
- Rebranded dummy messenger entry and placeholder text in English ARB translations
- Adjusted image URLs in home templates to point to healthyspread.com
- Updated pubspec.yaml description to reflect new brand name